### PR TITLE
Integrate file upload with third party api

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -50,11 +50,66 @@ class UploadsController < ApplicationController
       render json: { error: 'File upload failed' }, status: :internal_server_error
     end
   end
+
+  # New method to upload via third-party API (same as JavaScript implementation)
+  def create_via_third_party
+    if params[:file].blank?
+      render json: { error: 'No file provided' }, status: :bad_request
+      return
+    end
+    
+    file = params[:file]
+    
+    # Validate file type (optional - third-party API might have its own validation)
+    unless valid_file_type?(file.content_type)
+      render json: { error: 'Invalid file type.' }, status: :bad_request
+      return
+    end
+    
+    # Validate file size (max 10MB - adjust as needed)
+    if file.size > 10.megabytes
+      render json: { error: 'File size too large. Maximum 10MB allowed.' }, status: :bad_request
+      return
+    end
+    
+    begin
+      # Upload to third-party API
+      upload_result = upload_to_third_party_api(file)
+      
+      if upload_result[:success]
+        render json: { 
+          url: upload_result[:url],
+          filename: file.original_filename,
+          size: file.size,
+          content_type: file.content_type
+        }, status: :ok
+      else
+        render json: { error: upload_result[:error] || 'Upload failed' }, status: :internal_server_error
+      end
+      
+    rescue => e
+      Rails.logger.error "Third-party file upload error: #{e.message}"
+      render json: { error: 'File upload failed' }, status: :internal_server_error
+    end
+  end
   
   private
   
   def valid_image_type?(content_type)
     %w[image/jpeg image/jpg image/png image/gif image/webp].include?(content_type)
+  end
+
+  # More flexible file type validation for third-party API
+  def valid_file_type?(content_type)
+    # Allow images and common document types
+    allowed_types = %w[
+      image/jpeg image/jpg image/png image/gif image/webp image/svg+xml
+      application/pdf
+      text/plain
+      application/msword
+      application/vnd.openxmlformats-officedocument.wordprocessingml.document
+    ]
+    allowed_types.include?(content_type)
   end
   
   def generate_unique_filename(original_filename)
@@ -62,5 +117,57 @@ class UploadsController < ApplicationController
     timestamp = Time.current.to_i
     random_string = SecureRandom.hex(8)
     "#{timestamp}_#{random_string}#{extension}"
+  end
+
+  # Upload file to third-party API using the same endpoint as JavaScript
+  def upload_to_third_party_api(file)
+    require 'net/http'
+    require 'uri'
+    
+    uri = URI('https://kitintellect.tech/storage/public/api/upload/aaFacebook')
+    
+    # Create multipart form data
+    boundary = "----WebKitFormBoundary#{SecureRandom.hex(16)}"
+    
+    # Build the multipart body
+    body = []
+    body << "--#{boundary}\r\n"
+    body << "Content-Disposition: form-data; name=\"file\"; filename=\"#{file.original_filename}\"\r\n"
+    body << "Content-Type: #{file.content_type}\r\n"
+    body << "\r\n"
+    body << file.read
+    body << "\r\n--#{boundary}--\r\n"
+    
+    body_string = body.join
+    
+    # Create HTTP request
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    
+    request = Net::HTTP::Post.new(uri.path)
+    request['Content-Type'] = "multipart/form-data; boundary=#{boundary}"
+    request.body = body_string
+    
+    # Send request
+    response = http.request(request)
+    
+    if response.code == '200'
+      begin
+        result = JSON.parse(response.body)
+        if result['url']
+          { success: true, url: result['url'] }
+        else
+          { success: false, error: 'No URL returned from upload service' }
+        end
+      rescue JSON::ParserError
+        { success: false, error: 'Invalid response from upload service' }
+      end
+    else
+      { success: false, error: "Upload service returned status: #{response.code}" }
+    end
+    
+  rescue => e
+    Rails.logger.error "Third-party API upload error: #{e.message}"
+    { success: false, error: e.message }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -168,6 +168,7 @@ Rails.application.routes.draw do
   
   # File Upload API
   post '/api/upload', to: 'uploads#create'
+  post '/api/upload/third_party', to: 'uploads#create_via_third_party'
   
   # API routes
   namespace :api do


### PR DESCRIPTION
```
# Pull Request: Integrate Third-Party File Upload API

## 📋 **Description**
This PR introduces a new backend endpoint for file uploads that leverages an existing third-party storage API (`https://kitintellect.tech/storage/public/api/upload/aaFacebook`). This aligns the Rails application's file upload mechanism with the current frontend JavaScript implementation, ensuring consistency in file storage and offloading storage management to the external service.

## 🔧 **Changes Made**

### Backend Logic
- **`app/controllers/uploads_controller.rb`**:
    - Added a new public method `create_via_third_party` to handle file uploads to the specified third-party API.
    - Implemented `Net::HTTP` to construct and send multipart form data requests.
    - Included basic file validation (type and size) before proxying the upload.
    - Ensured the response format matches the expected JSON structure (`{ url: '...' }`).
    - Added a `valid_file_type?` helper for broader file type validation.
    - Added a `upload_to_third_party_api` private method to encapsulate the external API call logic.
- **`config/routes.rb`**:
    - Added a new `POST` route: `/api/upload/third_party` which maps to `uploads#create_via_third_party`.

## 🎯 **Business Benefits**

### Consistent File Management
- ✅ Ensures all file uploads (from both frontend and backend-initiated processes) use the same external storage service.
- ✅ Simplifies infrastructure by centralizing file storage with a dedicated third-party provider.
- ✅ Reduces the need for local storage management and scaling.
- ✅ Leverages an already established and used API endpoint.

## 🧪 **Testing**
- [ ] Verify that files uploaded via `/api/upload/third_party` successfully appear on the `kitintellect.tech` storage.
- [ ] Test with various file types (images, PDFs, text) to ensure `valid_file_type?` works as expected.
- [ ] Test with files exceeding the 10MB size limit to confirm appropriate error handling.
- [ ] Verify error responses for network issues or third-party API failures.
- [ ] Ensure existing `/api/upload` (local storage) functionality remains unaffected.

## 📝 **Migration Commands**
N/A - No database migrations are included in this PR.

## 🔄 **Database Schema Changes**
N/A - No database schema changes are included in this PR.

## 📚 **Documentation**
- Code comments within `uploads_controller.rb` explain the new methods and logic.
- Usage examples for frontend JavaScript and potential Rails controller usage are provided in the commit message/summary.

## 🚀 **Deployment Notes**
- This is an additive change; no existing functionality is altered or broken.
- The new endpoint is independent of the existing local file upload endpoint.

## 🔍 **Review Checklist**
- [ ] New route is correctly defined.
- [ ] `uploads_controller.rb` logic for `create_via_third_party` is sound.
- [ ] `Net::HTTP` usage for multipart form data is correct and robust.
- [ ] Error handling for API calls and file validations is comprehensive.
- [ ] Security considerations (e.g., file type/size validation) are addressed.
- [ ] No sensitive information is exposed.

## 📊 **Impact Assessment**
- **Risk Level**: Low (additive changes only, no existing functionality modified).
- **Backward Compatibility**: ✅ Full backward compatibility maintained.
- **Performance Impact**: Minimal (new endpoint for specific use case).
- **Database Size**: No impact.

## 🎉 **Post-Merge Tasks**
1. Update frontend code (e.g., customer, product, advertisement forms) to use the new `/api/upload/third_party` endpoint for file uploads where applicable.
2. Monitor third-party API integration for stability and performance.

---

**Branch**: `test1` → `main`  
**Commits**: 2 commits related to controller and route changes  
**Type**: Feature / API Integration  
**Priority**: Medium
```

---
<a href="https://cursor.com/background-agent?bcId=bc-12534df8-bbf1-4baa-aef6-495362c52313">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12534df8-bbf1-4baa-aef6-495362c52313">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>