### PR TITLE
Fix completed method call in delivery schedules

### DIFF
--- a/app/models/delivery_schedule.rb
+++ b/app/models/delivery_schedule.rb
@@ -14,6 +14,7 @@ class DeliverySchedule < ApplicationRecord
   validate :start_date_not_in_past
 
   scope :active, -> { where(status: 'active') }
+  scope :completed, -> { where(status: 'completed') }
   scope :by_customer, ->(customer_id) { where(customer_id: customer_id) }
   scope :by_delivery_person, ->(user_id) { where(user_id: user_id) }
 


### PR DESCRIPTION
```
# Pull Request: Fix: Add `completed` scope to DeliverySchedule model

## 📋 **Description**
This PR resolves a `NoMethodError` in `DeliverySchedulesController#index` by adding a missing `completed` scope to the `DeliverySchedule` model. The controller was attempting to call `@delivery_schedules.completed.count`, but this scope was not defined, leading to the error.

## 🔧 **Changes Made**

### Model Scopes
- **DeliverySchedule**: Added a new scope `completed` to filter records where `status` is 'completed'.

### Files Added/Modified
- `app/models/delivery_schedule.rb` - Added the `completed` scope.

## 🎯 **Business Benefits**
- ✅ Resolves a critical `NoMethodError` preventing the `/schedules` page from loading.
- ✅ Enables accurate display of completed delivery schedule counts.
- ✅ Improves application stability and user experience on the delivery schedules overview.

## 🧪 **Testing**
- [x] Verify the `/schedules` page loads without errors.
- [x] Confirm that the `@completed_schedules` count accurately reflects delivery schedules with a 'completed' status.

## 🚀 **Deployment Notes**
- This is a code change only; no database migrations are required.
- The change is additive and fixes a runtime error.

## 🔍 **Review Checklist**
- [x] Scope syntax is correct.
- [x] Scope logic correctly filters by `status: 'completed'`.
- [x] No unintended side effects introduced.

## 📊 **Impact Assessment**
- **Risk Level**: Low (additive code change, bug fix).
- **Backward Compatibility**: ✅ Full backward compatibility maintained.
- **Performance Impact**: Minimal (simple database query scope).

---

**Branch**: `test1` → `main`  
**Commits**: 1 commit  
**Type**: Bug Fix  
**Priority**: High
```

---
<a href="https://cursor.com/background-agent?bcId=bc-f1bb2c5a-af20-4356-a7cb-938832c02d95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1bb2c5a-af20-4356-a7cb-938832c02d95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>