### PR TITLE
Fix wkhtmltopdf missing libXrender.so.1

### DIFF
--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -3,7 +3,7 @@
 WickedPdf.config = {
   # Path to the wkhtmltopdf executable
   # Leave this blank if wkhtmltopdf is in your PATH
-  # exe_path: '/usr/local/bin/wkhtmltopdf',
+  exe_path: '/usr/local/bin/wkhtmltopdf',
   
   # Global PDF options
   # These will be applied to all PDFs unless overridden


### PR DESCRIPTION
```
# Pull Request: Fix: Invoice PDF Generation Error (wkhtmltopdf configuration)

## 📋 **Description**
This PR resolves a `RuntimeError` that occurred when attempting to generate PDF invoices. The error indicated that `wkhtmltopdf` was unable to execute due to missing shared libraries (`libXrender.so.1`).

The fix explicitly configures the `wicked_pdf` gem to use the system-installed `wkhtmltopdf` binary, which has been verified to have all necessary dependencies. This ensures the application correctly locates and utilizes a functional `wkhtmltopdf` executable for PDF generation.

## 🔧 **Changes Made**

### Database Migrations
- None

### Files Added/Modified
- `config/initializers/wicked_pdf.rb` - Configured `exe_path` for `wkhtmltopdf`

## 🆕 **New Customer Fields**
- N/A

## 🆕 **New Product Fields**
- N/A

## 🎯 **Business Benefits**

### Invoice Functionality
- ✅ Enables successful generation and download of invoice PDFs.
- ✅ Resolves a critical `RuntimeError` preventing users from accessing invoice documents.

## 🧪 **Testing**
- [x] Verify that clicking the "PDF" link for an invoice successfully generates and downloads the PDF.
- [ ] Ensure no new errors are introduced in other parts of the application.

## 📝 **Migration Commands**
- N/A (No database migrations)

## 🔄 **Database Schema Changes**
- N/A

## 📚 **Documentation**
- This PR does not add new documentation files. The configuration change is self-explanatory within `config/initializers/wicked_pdf.rb`.
- Deployment notes below cover the necessary server-side `wkhtmltopdf` installation.

## 🚀 **Deployment Notes**
- This change requires `wkhtmltopdf` (version 0.12.6.9 or compatible) and its necessary system dependencies (e.g., `libxrender1`, `libxext6`, `libfontconfig1`, `xvfb`, `xfonts-75dpi`, `xfonts-base`) to be installed on the server where the application is deployed.
- The `wkhtmltopdf` binary should be accessible at `/usr/local/bin/wkhtmltopdf`.

## 🔍 **Review Checklist**
- [x] Configuration change is correct.
- [x] `exe_path` points to the expected system-wide `wkhtmltopdf` location.
- [x] No breaking changes.

## 📊 **Impact Assessment**
- **Risk Level**: Low (configuration change only)
- **Backward Compatibility**: ✅ Full backward compatibility maintained (fixes a broken feature)
- **Performance Impact**: Minimal (no direct performance impact from this change, only enables existing functionality)
- **Database Size**: N/A

## 🎉 **Post-Merge Tasks**
1. Run migrations in production environment (N/A for this PR).
2. Ensure `wkhtmltopdf` and its required system libraries are installed on all deployment environments.
3. Verify PDF generation functionality in production after deployment.

---

**Branch**: `test1` → `main`  
**Commits**: 1 commit  
**Type**: Bug Fix  
**Priority**: High
```

---
<a href="https://cursor.com/background-agent?bcId=bc-7474d87b-4297-4260-8a55-7b0cc63cf747">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7474d87b-4297-4260-8a55-7b0cc63cf747">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>