### PR TITLE
Separate and show invoice tax percentages

### DIFF
--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -763,18 +763,42 @@
                 <span>TAXABLE AMOUNT</span>
                 <span>₹ <%= number_with_delimiter(taxable_amount.round(2), delimiter: ',') %></span>
               </div>
-              <% if total_cgst > 0 %>
-                <% cgst_rate = @invoice_items.sum { |item| item.product&.is_gst_applicable ? (item.product.total_cgst_percentage || 0) : 0 } / @invoice_items.select { |item| item.product&.is_gst_applicable }.count rescue 0 %>
+              <%
+                # Group tax amounts by individual tax rates
+                cgst_groups = {}
+                sgst_groups = {}
+                
+                @invoice_items.each do |item|
+                  if item.product&.is_gst_applicable
+                    base_amount = item.quantity * (item.unit_price || 0)
+                    
+                    cgst_rate = item.product.total_cgst_percentage || 0
+                    sgst_rate = item.product.total_sgst_percentage || 0
+                    
+                    if cgst_rate > 0
+                      cgst_amount = (base_amount * cgst_rate / 100).round(2)
+                      cgst_groups[cgst_rate] = (cgst_groups[cgst_rate] || 0) + cgst_amount
+                    end
+                    
+                    if sgst_rate > 0
+                      sgst_amount = (base_amount * sgst_rate / 100).round(2)
+                      sgst_groups[sgst_rate] = (sgst_groups[sgst_rate] || 0) + sgst_amount
+                    end
+                  end
+                end
+              %>
+              
+              <% cgst_groups.sort.each do |rate, amount| %>
                 <div class="tax-line">
-                  <span>CGST @<%= cgst_rate %>%</span>
-                  <span>₹ <%= number_with_delimiter(total_cgst.round(2), delimiter: ',') %></span>
+                  <span>CGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
+                  <span>₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
                 </div>
               <% end %>
-              <% if total_sgst > 0 %>
-                <% sgst_rate = @invoice_items.sum { |item| item.product&.is_gst_applicable ? (item.product.total_sgst_percentage || 0) : 0 } / @invoice_items.select { |item| item.product&.is_gst_applicable }.count rescue 0 %>
+              
+              <% sgst_groups.sort.each do |rate, amount| %>
                 <div class="tax-line">
-                  <span>SGST @<%= sgst_rate %>%</span>
-                  <span>₹ <%= number_with_delimiter(total_sgst.round(2), delimiter: ',') %></span>
+                  <span>SGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
+                  <span>₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
                 </div>
               <% end %>
               <% if total_igst > 0 %>

--- a/app/views/invoices/show.pdf.erb
+++ b/app/views/invoices/show.pdf.erb
@@ -748,18 +748,42 @@
                 <span class="tax-label">TAXABLE AMOUNT</span>
                 <span class="tax-amount">₹ <%= number_with_delimiter(taxable_amount.round(2), delimiter: ',') %></span>
               </div>
-              <% if total_cgst > 0 %>
-                <% cgst_rate = @invoice_items.sum { |item| item.product&.is_gst_applicable ? (item.product.total_cgst_percentage || 0) : 0 } / @invoice_items.select { |item| item.product&.is_gst_applicable }.count rescue 0 %>
+              <%
+                # Group tax amounts by individual tax rates
+                cgst_groups = {}
+                sgst_groups = {}
+                
+                @invoice_items.each do |item|
+                  if item.product&.is_gst_applicable
+                    base_amount = item.quantity * (item.unit_price || 0)
+                    
+                    cgst_rate = item.product.total_cgst_percentage || 0
+                    sgst_rate = item.product.total_sgst_percentage || 0
+                    
+                    if cgst_rate > 0
+                      cgst_amount = (base_amount * cgst_rate / 100).round(2)
+                      cgst_groups[cgst_rate] = (cgst_groups[cgst_rate] || 0) + cgst_amount
+                    end
+                    
+                    if sgst_rate > 0
+                      sgst_amount = (base_amount * sgst_rate / 100).round(2)
+                      sgst_groups[sgst_rate] = (sgst_groups[sgst_rate] || 0) + sgst_amount
+                    end
+                  end
+                end
+              %>
+              
+              <% cgst_groups.sort.each do |rate, amount| %>
                 <div class="tax-line">
-                  <span class="tax-label">CGST @<%= cgst_rate %>%</span>
-                  <span class="tax-amount">₹ <%= number_with_delimiter(total_cgst.round(2), delimiter: ',') %></span>
+                  <span class="tax-label">CGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
+                  <span class="tax-amount">₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
                 </div>
               <% end %>
-              <% if total_sgst > 0 %>
-                <% sgst_rate = @invoice_items.sum { |item| item.product&.is_gst_applicable ? (item.product.total_sgst_percentage || 0) : 0 } / @invoice_items.select { |item| item.product&.is_gst_applicable }.count rescue 0 %>
+              
+              <% sgst_groups.sort.each do |rate, amount| %>
                 <div class="tax-line">
-                  <span class="tax-label">SGST @<%= sgst_rate %>%</span>
-                  <span class="tax-amount">₹ <%= number_with_delimiter(total_sgst.round(2), delimiter: ',') %></span>
+                  <span class="tax-label">SGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
+                  <span class="tax-amount">₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
                 </div>
               <% end %>
               <% if total_igst > 0 %>

--- a/app/views/invoices/show_print.pdf.erb
+++ b/app/views/invoices/show_print.pdf.erb
@@ -748,18 +748,42 @@
                 <span class="tax-label">TAXABLE AMOUNT</span>
                 <span class="tax-amount">₹ <%= number_with_delimiter(taxable_amount.round(2), delimiter: ',') %></span>
               </div>
-              <% if total_cgst > 0 %>
-                <% cgst_rate = @invoice_items.sum { |item| item.product&.is_gst_applicable ? (item.product.total_cgst_percentage || 0) : 0 } / @invoice_items.select { |item| item.product&.is_gst_applicable }.count rescue 0 %>
+              <%
+                # Group tax amounts by individual tax rates
+                cgst_groups = {}
+                sgst_groups = {}
+                
+                @invoice_items.each do |item|
+                  if item.product&.is_gst_applicable
+                    base_amount = item.quantity * (item.unit_price || 0)
+                    
+                    cgst_rate = item.product.total_cgst_percentage || 0
+                    sgst_rate = item.product.total_sgst_percentage || 0
+                    
+                    if cgst_rate > 0
+                      cgst_amount = (base_amount * cgst_rate / 100).round(2)
+                      cgst_groups[cgst_rate] = (cgst_groups[cgst_rate] || 0) + cgst_amount
+                    end
+                    
+                    if sgst_rate > 0
+                      sgst_amount = (base_amount * sgst_rate / 100).round(2)
+                      sgst_groups[sgst_rate] = (sgst_groups[sgst_rate] || 0) + sgst_amount
+                    end
+                  end
+                end
+              %>
+              
+              <% cgst_groups.sort.each do |rate, amount| %>
                 <div class="tax-line">
-                  <span class="tax-label">CGST @<%= cgst_rate %>%</span>
-                  <span class="tax-amount">₹ <%= number_with_delimiter(total_cgst.round(2), delimiter: ',') %></span>
+                  <span class="tax-label">CGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
+                  <span class="tax-amount">₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
                 </div>
               <% end %>
-              <% if total_sgst > 0 %>
-                <% sgst_rate = @invoice_items.sum { |item| item.product&.is_gst_applicable ? (item.product.total_sgst_percentage || 0) : 0 } / @invoice_items.select { |item| item.product&.is_gst_applicable }.count rescue 0 %>
+              
+              <% sgst_groups.sort.each do |rate, amount| %>
                 <div class="tax-line">
-                  <span class="tax-label">SGST @<%= sgst_rate %>%</span>
-                  <span class="tax-amount">₹ <%= number_with_delimiter(total_sgst.round(2), delimiter: ',') %></span>
+                  <span class="tax-label">SGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
+                  <span class="tax-amount">₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
                 </div>
               <% end %>
               <% if total_igst > 0 %>


### PR DESCRIPTION
# Pull Request: Enhance Invoice Tax Display: Group by Rate

## 📋 **Description**
This PR addresses a user request to display CGST and SGST tax amounts separately, grouped by their individual tax percentages, rather than showing a single merged/averaged rate across all invoice items. This improves clarity and accuracy for invoices containing products subject to different tax rates.

## 🔧 **Changes Made**

### Files Modified
- `app/views/invoices/show.html.erb`
- `app/views/invoices/show.pdf.erb`
- `app/views/invoices/show_print.pdf.erb`

### Details
Implemented new logic within the invoice templates to:
1.  Iterate through invoice items and group CGST and SGST amounts by their respective percentage rates.
2.  Calculate the total tax amount for each unique rate group.
3.  Display each unique tax rate (e.g., "CGST @5%", "SGST @6%") and its corresponding calculated total tax amount on a separate line.

## 🎯 **Business Benefits**
- ✅ **Improved Clarity:** Invoices now clearly show tax breakdowns for each unique CGST/SGST rate.
- ✅ **Enhanced Accuracy:** Correctly reflects tax amounts for products with varying rates.
- ✅ **Better User Understanding:** Users can easily see how different tax rates apply to their invoice.

## 🧪 **Testing**
- [ ] Verify invoices with single tax rates (e.g., all 5%) display correctly.
- [ ] Verify invoices with multiple tax rates (e.g., 5% and 6%) display separate lines for each rate.
- [ ] Confirm tax amounts are correctly calculated for each grouped rate.
- [ ] Check display in HTML, PDF, and Print PDF versions.
- [ ] Ensure no regressions to other invoice calculations (e.g., total amount).

## 📚 **Documentation**
Changes are self-contained within the updated invoice view templates.

## 🚀 **Deployment Notes**
- This is a display-only change; no database or backend logic modifications are involved.
- No downtime expected.

## 🔍 **Review Checklist**
- [ ] Tax grouping logic is correct.
- [ ] Tax amounts are accurate for each rate.
- [ ] Display formatting (e.g., integer rates) is correct.
- [ ] Consistency across all three invoice views.
- [ ] No unintended side effects on other invoice calculations.

## 📊 **Impact Assessment**
- **Risk Level**: Low (display logic only)
- **Backward Compatibility**: ✅ Full backward compatibility maintained (no data structure changes)
- **Performance Impact**: Negligible (minor client-side rendering logic)

## 🎉 **Post-Merge Tasks**
None beyond standard deployment.

---

**Branch**: `test1` → `main`
**Commits**: 3 commits (implied by file changes)
**Type**: Feature / UI Enhancement
**Priority**: Medium

---
<a href="https://cursor.com/background-agent?bcId=bc-987cd4ed-d40c-488a-af9b-fbd2ad151c91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-987cd4ed-d40c-488a-af9b-fbd2ad151c91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>