### PR TITLE
Process gst values sequentially

### DIFF
--- a/app/views/invoices/show.html.erb
+++ b/app/views/invoices/show.html.erb
@@ -788,19 +788,28 @@
                 end
               %>
               
-              <% cgst_groups.sort.each do |rate, amount| %>
+              <% 
+                # Get all unique tax rates and display CGST/SGST alternately for each rate
+                all_rates = (cgst_groups.keys + sgst_groups.keys).uniq.sort
+                all_rates.each do |rate|
+                  if cgst_groups[rate] && cgst_groups[rate] > 0
+              %>
                 <div class="tax-line">
                   <span>CGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
-                  <span>₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
+                  <span>₹ <%= number_with_delimiter(cgst_groups[rate].round(2), delimiter: ',') %></span>
                 </div>
-              <% end %>
-              
-              <% sgst_groups.sort.each do |rate, amount| %>
+              <% 
+                  end
+                  if sgst_groups[rate] && sgst_groups[rate] > 0
+              %>
                 <div class="tax-line">
                   <span>SGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
-                  <span>₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
+                  <span>₹ <%= number_with_delimiter(sgst_groups[rate].round(2), delimiter: ',') %></span>
                 </div>
-              <% end %>
+              <% 
+                  end
+                end 
+              %>
               <% if total_igst > 0 %>
                 <% igst_rate = @invoice_items.sum { |item| item.product&.is_gst_applicable ? (item.product.total_igst_percentage || 0) : 0 } / @invoice_items.select { |item| item.product&.is_gst_applicable }.count rescue 0 %>
                 <div class="tax-line">

--- a/app/views/invoices/show.pdf.erb
+++ b/app/views/invoices/show.pdf.erb
@@ -773,19 +773,28 @@
                 end
               %>
               
-              <% cgst_groups.sort.each do |rate, amount| %>
+              <% 
+                # Get all unique tax rates and display CGST/SGST alternately for each rate
+                all_rates = (cgst_groups.keys + sgst_groups.keys).uniq.sort
+                all_rates.each do |rate|
+                  if cgst_groups[rate] && cgst_groups[rate] > 0
+              %>
                 <div class="tax-line">
                   <span class="tax-label">CGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
-                  <span class="tax-amount">₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
+                  <span class="tax-amount">₹ <%= number_with_delimiter(cgst_groups[rate].round(2), delimiter: ',') %></span>
                 </div>
-              <% end %>
-              
-              <% sgst_groups.sort.each do |rate, amount| %>
+              <% 
+                  end
+                  if sgst_groups[rate] && sgst_groups[rate] > 0
+              %>
                 <div class="tax-line">
                   <span class="tax-label">SGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
-                  <span class="tax-amount">₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
+                  <span class="tax-amount">₹ <%= number_with_delimiter(sgst_groups[rate].round(2), delimiter: ',') %></span>
                 </div>
-              <% end %>
+              <% 
+                  end
+                end 
+              %>
               <% if total_igst > 0 %>
                 <% igst_rate = @invoice_items.sum { |item| item.product&.is_gst_applicable ? (item.product.total_igst_percentage || 0) : 0 } / @invoice_items.select { |item| item.product&.is_gst_applicable }.count rescue 0 %>
                 <div class="tax-line">

--- a/app/views/invoices/show_print.pdf.erb
+++ b/app/views/invoices/show_print.pdf.erb
@@ -773,19 +773,28 @@
                 end
               %>
               
-              <% cgst_groups.sort.each do |rate, amount| %>
+              <% 
+                # Get all unique tax rates and display CGST/SGST alternately for each rate
+                all_rates = (cgst_groups.keys + sgst_groups.keys).uniq.sort
+                all_rates.each do |rate|
+                  if cgst_groups[rate] && cgst_groups[rate] > 0
+              %>
                 <div class="tax-line">
                   <span class="tax-label">CGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
-                  <span class="tax-amount">₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
+                  <span class="tax-amount">₹ <%= number_with_delimiter(cgst_groups[rate].round(2), delimiter: ',') %></span>
                 </div>
-              <% end %>
-              
-              <% sgst_groups.sort.each do |rate, amount| %>
+              <% 
+                  end
+                  if sgst_groups[rate] && sgst_groups[rate] > 0
+              %>
                 <div class="tax-line">
                   <span class="tax-label">SGST @<%= rate.to_i == rate ? rate.to_i : rate %>%</span>
-                  <span class="tax-amount">₹ <%= number_with_delimiter(amount.round(2), delimiter: ',') %></span>
+                  <span class="tax-amount">₹ <%= number_with_delimiter(sgst_groups[rate].round(2), delimiter: ',') %></span>
                 </div>
-              <% end %>
+              <% 
+                  end
+                end 
+              %>
               <% if total_igst > 0 %>
                 <% igst_rate = @invoice_items.sum { |item| item.product&.is_gst_applicable ? (item.product.total_igst_percentage || 0) : 0 } / @invoice_items.select { |item| item.product&.is_gst_applicable }.count rescue 0 %>
                 <div class="tax-line">


### PR DESCRIPTION
# Pull Request: Reorder CGST/SGST Display on Invoices

## 📋 **Description**
This PR addresses an issue where CGST (Central Goods and Services Tax) and SGST (State Goods and Services Tax) were displayed grouped separately on invoices (all CGST first, then all SGST). It modifies the invoice views to display CGST and SGST alternately for each tax rate, improving readability and adhering to the requested display order (CGST @X%, SGST @X%, CGST @Y%, SGST @Y%, etc.).

## 🔧 **Changes Made**

### Database Migrations
N/A (No database migrations were required for this change.)

### Files Added/Modified
- `app/views/invoices/show.html.erb` - Main invoice view
- `app/views/invoices/show.pdf.erb` - PDF export view
- `app/views/invoices/show_print.pdf.erb` - Print PDF view

## 🆕 **New Customer Fields**
N/A (No new customer fields were added.)

## 🆕 **New Product Fields**
N/A (No new product fields were added.)

## 🎯 **Business Benefits**

### Customer Enhancements
N/A (This PR is not directly related to customer data enhancements.)

### Product Enhancements
N/A (This PR is not directly related to product data enhancements.)

### Overall Benefits
- ✅ Improves readability and clarity of tax breakdowns on invoices.
- ✅ Aligns invoice display with the user's preferred alternating CGST/SGST pattern for each tax rate.
- ✅ Enhances user experience by presenting tax information in a more organized and intuitive manner.

## 🧪 **Testing**
- [ ] Verify that CGST and SGST taxes are displayed alternately (e.g., CGST @5%, SGST @5%, CGST @6%, SGST @6%) on:
    -   The main invoice view (`app/views/invoices/show.html.erb`)
    -   The PDF export view (`app/views/invoices/show.pdf.erb`)
    -   The print PDF view (`app/views/invoices/show_print.pdf.erb`)
- [ ] Ensure all tax amounts are correctly calculated and displayed.
- [ ] Confirm no breaking changes to existing invoice functionality.

## 📝 **Migration Commands**
N/A (No database migrations are involved.)

## 🔄 **Database Schema Changes**

### Customers Table
N/A (No changes to the `customers` table schema.)

### Products Table
N/A (No changes to the `products` table schema.)

## 📚 **Documentation**
N/A (No new documentation files were added or existing ones updated.)

## 🚀 **Deployment Notes**
-   These are additive changes to view logic only.
-   No existing functionality is affected.
-   No database changes or backend logic modifications.
-   Deployment should be straightforward with no expected downtime.

## 🔍 **Review Checklist**
- [ ] Tax display order is correct (CGST, SGST, CGST, SGST for each rate).
- [ ] Tax amounts are accurate.
- [ ] No regressions in invoice display or other parts of the application.
- [ ] Code changes are clear and maintainable.

## 📊 **Impact Assessment**
-   **Risk Level**: Low (UI/frontend change only).
-   **Backward Compatibility**: ✅ Full backward compatibility maintained.
-   **Performance Impact**: Negligible (minor change in view rendering logic).
-   **Database Size**: No change.

## 🎉 **Post-Merge Tasks**
N/A

---

**Branch**: `feature/reorder-invoice-taxes` → `main`  
**Commits**: Multiple commits related to invoice tax display reordering.  
**Type**: UI Improvement / Bug Fix  
**Priority**: Medium

---
<a href="https://cursor.com/background-agent?bcId=bc-bc1cc198-f20e-4913-b59d-a454ec6584b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc1cc198-f20e-4913-b59d-a454ec6584b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>