### PR TITLE
Fix invoice url generation

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -86,8 +86,12 @@ class Invoice < ApplicationRecord
     update!(shared_at: Time.current)
   end
 
-  def public_url
-    Rails.application.routes.url_helpers.public_invoice_url(token: share_token)
+  def public_url(host: nil, port: nil)
+    url_options = { token: share_token }
+    url_options[:host] = host if host.present?
+    url_options[:port] = port if port.present?
+    
+    Rails.application.routes.url_helpers.public_invoice_url(url_options)
   end
   
   def profit_amount

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,11 @@ module DeliveryManagement
     # Allow HTTPS origin from external tunneling tools like ngrok
     # config.action_controller.forgery_protection_origin_check = true
 
+    # Set default URL options for all environments
+    # This can be overridden in specific environment files
+    config.action_controller.default_url_options = { host: "localhost", port: 3000 }
+    config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,6 +47,9 @@ Rails.application.configure do
   # Set localhost to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 
+  # Set default URL options for the main application routes
+  config.action_controller.default_url_options = { host: "localhost", port: 3000 }
+
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -58,7 +58,10 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
+  config.action_mailer.default_url_options = { host: "atmanirbharfarm.work.gd" }
+
+  # Set default URL options for the main application routes
+  config.action_controller.default_url_options = { host: "atmanirbharfarm.work.gd" }
 
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,6 +39,9 @@ Rails.application.configure do
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: "example.com" }
 
+  # Set default URL options for the main application routes
+  config.action_controller.default_url_options = { host: "example.com" }
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/initializers/url_options.rb
+++ b/config/initializers/url_options.rb
@@ -1,0 +1,27 @@
+# config/initializers/url_options.rb
+# Configure default URL options for all contexts
+
+Rails.application.configure do
+  # Set default URL options based on environment
+  default_options = case Rails.env
+                   when 'production'
+                     { host: 'atmanirbharfarm.work.gd', protocol: 'https' }
+                   when 'development'
+                     { host: 'localhost', port: 3000, protocol: 'http' }
+                   when 'test'
+                     { host: 'example.com', protocol: 'http' }
+                   else
+                     { host: 'localhost', port: 3000, protocol: 'http' }
+                   end
+
+  # Set for Action Controller
+  config.action_controller.default_url_options = default_options
+  
+  # Set for Action Mailer
+  config.action_mailer.default_url_options = default_options
+end
+
+# Ensure URL helpers work in console and background jobs
+Rails.application.reloader.to_prepare do
+  Rails.application.routes.default_url_options = Rails.application.config.action_controller.default_url_options
+end


### PR DESCRIPTION
# Pull Request: Fix Missing Host Error for Rails URL Helpers

## 📋 **Description**
This PR resolves the "Missing host to link to!" error encountered when generating full URLs in Rails, particularly outside of a request context (e.g., console, background jobs, or model methods). The fix ensures that `Rails.application.routes.url_helpers` and `ActionMailer` always have the necessary host information to generate valid URLs.

## 🔧 **Changes Made**

### Files Added/Modified
- `app/models/invoice.rb`: Enhanced `public_url` method to optionally accept `host` and `port` parameters for greater flexibility.
- `config/application.rb`: Added global `default_url_options` for `ActionController` and `ActionMailer`.
- `config/environments/development.rb`: Configured `default_url_options` for the development environment.
- `config/environments/production.rb`: Configured `default_url_options` for the production environment with the correct host.
- `config/environments/test.rb`: Configured `default_url_options` for the test environment.
- `config/initializers/url_options.rb`: **New file** to centralize and ensure `Rails.application.routes.default_url_options` are set for all contexts, including console and background jobs.

## 🎯 **Business Benefits**
- ✅ Ensures public invoice links are correctly generated and accessible from all application contexts (e.g., when sent via background jobs, or generated in console/API).
- ✅ Improves the robustness and reliability of URL generation throughout the application.
- ✅ Provides flexibility to override default host/port when needed (e.g., for specific sharing scenarios).

## 🧪 **Testing**
- [x] Default URL options are correctly applied in `development`, `production`, and `test` environments.
- [x] `Rails.application.routes.url_helpers.public_invoice_url` works without explicit host in console/debugger.
- [x] `Invoice#public_url` method successfully generates URLs.
- [x] `Invoice#public_url` method correctly applies explicit `host` and `port` parameters when provided.

## 📚 **Documentation**
- The new initializer `config/initializers/url_options.rb` serves as central documentation for default URL option configuration.

## 🚀 **Deployment Notes**
- These are configuration changes and do not affect database schema.
- An application restart is required for the new initializer and environment configurations to take effect.

## 🔍 **Review Checklist**
- [ ] Default URL options are appropriate for each environment.
- [ ] The `url_options.rb` initializer correctly sets global route options.
- [ ] The `Invoice#public_url` method maintains backward compatibility while adding flexibility.
- [ ] No unintended side effects or breaking changes.

## 📊 **Impact Assessment**
- **Risk Level**: Low (configuration and additive changes only)
- **Backward Compatibility**: ✅ Full backward compatibility maintained
- **Performance Impact**: Minimal (configuration loading)
- **Database Size**: No change

## 🎉 **Post-Merge Tasks**
1. Restart the application in all environments (development, staging, production).
2. Verify that public invoice links are correctly generated and accessible.

---

**Branch**: `test1` → `main`  
**Commits**: Multiple commits for configuration and model updates  
**Type**: Bug Fix / Configuration  
**Priority**: High

---
<a href="https://cursor.com/background-agent?bcId=bc-844dc447-6213-4cb4-875f-0fd3d4da57c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-844dc447-6213-4cb4-875f-0fd3d4da57c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>