### PR TITLE
Update invoice link for WhatsApp message

### DIFF
--- a/app/controllers/invoices_controller.rb
+++ b/app/controllers/invoices_controller.rb
@@ -237,8 +237,8 @@ end
     @invoice.generate_share_token if @invoice.share_token.blank?
     @invoice.save! if @invoice.changed?
     
-    # Generate public URL with explicit host
-    host = request.host_with_port || Rails.application.config.action_controller.default_url_options[:host] || 'atmanirbharfarm.work.gd'
+    # Generate public URL with explicit host (without port for WhatsApp)
+    host = request.host || Rails.application.config.action_controller.default_url_options[:host] || 'atmanirbharfarm.work.gd'
     public_url = @invoice.public_pdf_url(host: host)
     
     # Build WhatsApp message
@@ -351,7 +351,8 @@ end
       💰 Amount: ₹#{ActionController::Base.helpers.number_with_delimiter(invoice.total_amount)}
       📅 Date: #{invoice.invoice_date.strftime('%d %B %Y')}
 
-      Download your invoice PDF: #{public_url}
+      Download your invoice PDF:
+#{public_url}
 
       Thank you for your business! 🙏
       - #{company_name}

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -117,7 +117,7 @@ class Invoice < ApplicationRecord
     
     url_options[:port] = port if port.present?
     
-    Rails.application.routes.url_helpers.public_invoice_download_url(url_options)
+    Rails.application.routes.url_helpers.public_invoice_url(url_options)
   end
   
   def profit_amount

--- a/app/views/invoices/public_view.html.erb
+++ b/app/views/invoices/public_view.html.erb
@@ -999,48 +999,17 @@
       </table>
     </div>
 
-    <!-- Share Again Section (visible only on screen) -->
+    <!-- Download Section (visible only on screen) -->
     <div class="no-print">
       <div class="share-card">
-        <h6 class="share-title">
-          <i class="fab fa-whatsapp" style="color: #25d366; margin-right: 8px;"></i>
-          Share this invoice
-        </h6>
-        <p class="share-text">
-          You can share this invoice link with others or save it for your records.
-        </p>
-        <div class="btn-group" role="group">
-          <button class="btn btn-outline-success" onclick="copyToClipboard()">
-            <span style="margin-right: 8px;">📋</span>Copy Link
-          </button>
-          <button class="btn btn-outline-primary" onclick="shareInvoice()">
-            <span style="margin-right: 8px;">📤</span>Share
-          </button>
-          <a href="<%= public_invoice_download_path(@invoice.share_token, format: :pdf) %>" class="btn btn-outline-danger" target="_blank">
+        <div style="text-align: center; margin-top: 30px;">
+          <a href="<%= public_invoice_download_path(@invoice.share_token, format: :pdf) %>" class="btn btn-primary btn-lg" style="padding: 15px 30px; font-size: 18px; background-color: #007bff; border-color: #007bff; text-decoration: none; color: white; border-radius: 8px; display: inline-block;">
             <span style="margin-right: 8px;">📄</span>Download PDF
           </a>
         </div>
       </div>
     </div>
 
-    <script>
-      function copyToClipboard() {
-        navigator.clipboard.writeText(window.location.href).then(function() {
-          alert('Invoice link copied to clipboard!');
-        });
-      }
-      
-      function shareInvoice() {
-        if (navigator.share) {
-          navigator.share({
-            title: 'Invoice #<%= @invoice.formatted_number || @invoice.invoice_number || @invoice.id %>',
-            text: 'Please find your invoice details',
-            url: window.location.href
-          });
-        } else {
-          copyToClipboard();
-        }
-      }
-    </script>
+
   </body>
 </html>


### PR DESCRIPTION
# Pull Request: Enhance Invoice Link Experience: View Page Before Download

## 📋 **Description**
This PR refactors the invoice link generation and public view page to provide a more intuitive user experience for WhatsApp invoice links. Instead of directly downloading the PDF, users will now first land on a public invoice details page with a clear "Download PDF" button. This also resolves the issue of port numbers appearing in the generated links.

## 🔧 **Changes Made**

### Files Added/Modified
- `app/controllers/invoices_controller.rb`
- `app/models/invoice.rb`
- `app/views/invoices/public_view.html.erb`

## 🎯 **Business Benefits**

### User Experience Enhancements
- ✅ **Improved Flow**: Users can review invoice details on a dedicated page before initiating a download, preventing accidental downloads and providing context.
- ✅ **Cleaner URLs**: WhatsApp links no longer include unnecessary port numbers, resulting in more professional and reliable links.
- ✅ **Simplified Interface**: The public invoice view page is streamlined to focus solely on displaying invoice details and offering a single, prominent "Download PDF" action.
- ✅ **Public Accessibility**: Invoice details and download remain accessible without authentication, meeting the requirement for public access.

## 🧪 **Testing**
- [ ] Verify WhatsApp links are generated without port numbers.
- [ ] Verify clicking the WhatsApp link navigates to the public invoice view page.
- [ ] Verify the public invoice view page displays invoice details correctly.
- [ ] Verify the public invoice view page has **only one** "Download PDF" button.
- [ ] Verify clicking the "Download PDF" button triggers the PDF download.
- [ ] Verify no authentication is required for the public view page.

## 🚀 **Deployment Notes**
- These are functional changes to URL generation and view logic.
- No database migrations or schema changes are involved.
- All changes are additive or modify existing logic without impacting data integrity.

## 🔍 **Review Checklist**
- [ ] URL generation logic for WhatsApp links correctly uses `request.host` (without port).
- [ ] `Invoice#public_pdf_url` correctly points to the public view route (`public_invoice_url`).
- [ ] `public_view.html.erb` is simplified as per requirements (single download button, no other actions).
- [ ] Associated JavaScript for removed buttons is also removed.
- [ ] Public view page remains unauthenticated.

## 📊 **Impact Assessment**
- **Risk Level**: Low (functional changes only, no data migration).
- **Backward Compatibility**: ✅ Full backward compatibility maintained for existing invoices and data.
- **Performance Impact**: Minimal.

## 🎉 **Post-Merge Tasks**
1. Communicate the updated user flow for invoice links to relevant stakeholders.

---

**Branch**: `test1` → `main`  
**Commits**: 3 commits related to URL fix and view simplification  
**Type**: Feature / UX Improvement  
**Priority**: Medium

---
<a href="https://cursor.com/background-agent?bcId=bc-ffa8dca4-6e69-476e-bc68-5a4130b10491">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ffa8dca4-6e69-476e-bc68-5a4130b10491">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>