### PR TITLE
Fix wkhtmltopdf path for pdf generation

### DIFF
--- a/config/initializers/wicked_pdf.rb
+++ b/config/initializers/wicked_pdf.rb
@@ -1,10 +1,59 @@
 # config/initializers/wicked_pdf.rb
 
+# Dynamically detect wkhtmltopdf path
+def detect_wkhtmltopdf_path
+  # Try common system paths first
+  system_paths = [
+    '/usr/local/bin/wkhtmltopdf',
+    '/usr/bin/wkhtmltopdf',
+    '/bin/wkhtmltopdf'
+  ]
+  
+  system_paths.each do |path|
+    return path if File.executable?(path)
+  end
+  
+  # Try to find via which command
+  which_result = `which wkhtmltopdf 2>/dev/null`.strip
+  return which_result unless which_result.empty?
+  
+  # Try RVM gem paths (common in production with RVM)
+  if ENV['HOME']
+    # Try current Ruby version
+    rvm_paths = [
+      "#{ENV['HOME']}/.rvm/gems/ruby-#{RUBY_VERSION}/bin/wkhtmltopdf",
+      "#{ENV['HOME']}/.rvm/gems/ruby-#{RUBY_VERSION}@global/bin/wkhtmltopdf"
+    ]
+    
+    rvm_paths.each do |path|
+      return path if File.executable?(path)
+    end
+    
+    # Try to find any Ruby version in RVM gems
+    rvm_gems_dir = "#{ENV['HOME']}/.rvm/gems"
+    if Dir.exist?(rvm_gems_dir)
+      Dir.glob("#{rvm_gems_dir}/ruby-*/bin/wkhtmltopdf").each do |path|
+        return path if File.executable?(path)
+      end
+    end
+  end
+  
+  # Try wkhtmltopdf-binary gem path as last resort
+  begin
+    return Gem.bin_path('wkhtmltopdf-binary', 'wkhtmltopdf')
+  rescue Gem::GemNotFoundException
+    # Gem not found, continue
+  end
+  
+  # If all else fails, let wicked_pdf try to find it
+  nil
+end
+
 # Base configuration
 base_config = {
   # Path to the wkhtmltopdf executable
-  # Use system-installed wkhtmltopdf instead of gem binary for Ubuntu 25.04 compatibility
-  exe_path: '/usr/local/bin/wkhtmltopdf',
+  # Dynamically detect the correct path for the current environment
+  exe_path: detect_wkhtmltopdf_path,
 
   # Global PDF options
   # These will be applied to all PDFs unless overridden
@@ -62,6 +111,17 @@ WickedPdf.configure do |config|
       config.send("#{key}=", value)
     end
   end
+end
+
+# Log the detected path for debugging
+detected_path = detect_wkhtmltopdf_path
+Rails.logger.info "WickedPDF configured with wkhtmltopdf path: #{detected_path || 'auto-detect'}"
+
+# In production, also log some additional debugging info
+if Rails.env.production?
+  Rails.logger.info "Ruby version: #{RUBY_VERSION}"
+  Rails.logger.info "HOME environment: #{ENV['HOME']}"
+  Rails.logger.info "PATH environment: #{ENV['PATH']}"
 end
 
 # MIME type registration


### PR DESCRIPTION
# Pull Request: Fix: Dynamic wkhtmltopdf Path Detection for WickedPDF

## 📋 **Description**
This PR resolves a `RuntimeError` where `wicked_pdf` failed to generate PDFs in production due to an incorrect and hardcoded `wkhtmltopdf` binary path. The configuration has been updated to dynamically detect the correct `wkhtmltopdf` executable, supporting various environments including RVM installations.

## 🔧 **Changes Made**

### Database Migrations
N/A - No database migrations are included in this PR.

### Files Added/Modified
- `config/initializers/wicked_pdf.rb` - Modified to include a robust `detect_wkhtmltopdf_path` function and enhanced logging.

## 🎯 **Business Benefits**

- ✅ **Eliminates Production Errors**: Resolves the `RuntimeError: Bad wkhtmltopdf's path` preventing PDF generation.
- ✅ **Improved Reliability**: Ensures `wicked_pdf` can find the correct `wkhtmltopdf` binary across different deployment environments (e.g., system-wide, RVM, gem-installed).
- ✅ **Reduced Manual Configuration**: Automates the detection of the binary path, reducing the need for manual adjustments.

## 🧪 **Testing**
- [ ] Verify PDF generation works correctly in development after applying the change.
- [ ] If possible, deploy to a staging environment to confirm dynamic path detection.
- [ ] Check Rails logs for the `WickedPDF configured with wkhtmltopdf path:` message to confirm the correct path is detected.

## 📝 **Migration Commands**
N/A - No database migrations are included in this PR.

## 🔄 **Database Schema Changes**
N/A - No database schema changes are included in this PR.

## 📚 **Documentation**
- In-code comments within `config/initializers/wicked_pdf.rb` explain the dynamic path detection logic.
- Enhanced logging has been added to `config/initializers/wicked_pdf.rb` to output the detected `wkhtmltopdf` path and relevant environment details (Ruby version, HOME, PATH) in production logs, aiding in debugging.

## 🚀 **Deployment Notes**
- This is a configuration change only; no database migrations or breaking changes are introduced.
- The change is additive and should not negatively affect existing functionality.
- The dynamic path detection is designed to be robust and adapt to various `wkhtmltopdf` installation locations.

## 🔍 **Review Checklist**
- [ ] Dynamic path detection logic covers common scenarios (system paths, `which` command, RVM, `wkhtmltopdf-binary` gem).
- [ ] Logging is clear and helpful for debugging in production.
- [ ] No breaking changes or regressions are introduced.
- [ ] The solution addresses the root cause of the `RuntimeError`.

## 📊 **Impact Assessment**
- **Risk Level**: Low (configuration fix, no core application logic changes)
- **Backward Compatibility**: ✅ Full backward compatibility maintained
- **Performance Impact**: Minimal (path detection runs once during application boot)
- **Database Size**: N/A

## 🎉 **Post-Merge Tasks**
1.  Monitor production logs to confirm successful `wkhtmltopdf` path detection and PDF generation.

---

**Branch**: `test1` → `main`  
**Commits**: 1 commit with configuration update  
**Type**: Bug Fix / Configuration  
**Priority**: High

---
<a href="https://cursor.com/background-agent?bcId=bc-dbafb5bd-5821-4e31-9ba5-12f3166557e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbafb5bd-5821-4e31-9ba5-12f3166557e2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>