### PR TITLE
Fix undefined api_customers_path in delivery assignments

### DIFF
--- a/app/views/delivery_assignments/new.html.erb
+++ b/app/views/delivery_assignments/new.html.erb
@@ -63,7 +63,7 @@
           </div>
 
           <!-- Customer Selection with Search -->
-          <div class="col-md-6" data-controller="searchable-select" data-searchable-select-url-value="<%= api_customers_path %>" data-searchable-select-placeholder-value="Search customers...">
+          <div class="col-md-6" data-controller="searchable-select" data-searchable-select-url-value="<%= api_customers_search_path %>" data-searchable-select-placeholder-value="Search customers...">
             <%= form.label :customer_id, class: "form-label" %>
             <%= form.select :customer_id, 
                 options_for_select([['Select Customer', '']] + @customers.map { |c| [c.name, c.id] }, @delivery_assignment.customer_id), 
@@ -75,7 +75,7 @@
           </div>
 
           <!-- Delivery Person Selection with Search -->
-          <div class="col-md-6" data-controller="searchable-select" data-searchable-select-url-value="<%= api_delivery_people_path %>" data-searchable-select-placeholder-value="Search delivery people...">
+          <div class="col-md-6" data-controller="searchable-select" data-searchable-select-url-value="<%= api_delivery_people_search_path %>" data-searchable-select-placeholder-value="Search delivery people...">
             <%= form.label :delivery_person_id, "Delivery Person", class: "form-label" %>
             <%= form.select :delivery_person_id, 
                 options_for_select([['Select Delivery Person', '']] + @delivery_people.map { |dp| [dp.name, dp.id] }, @delivery_assignment.user_id), 
@@ -87,7 +87,7 @@
           </div>
 
           <!-- Product Selection with Search -->
-          <div class="col-md-6" data-controller="searchable-select" data-searchable-select-url-value="<%= api_products_path %>" data-searchable-select-placeholder-value="Search products...">
+          <div class="col-md-6" data-controller="searchable-select" data-searchable-select-url-value="<%= api_products_search_path %>" data-searchable-select-placeholder-value="Search products...">
             <%= form.label :product_id, class: "form-label" %>
             <%= form.select :product_id, 
                 options_for_select([['Select Product', '']] + @products.map { |p| ["#{p.name} - Rs#{p.price}", p.id] }, @delivery_assignment.product_id), 


### PR DESCRIPTION
# Pull Request: Fix NameError in DeliveryAssignments#new View

## 📋 **Description**
This PR resolves a `NameError` occurring in the `DeliveryAssignments#new` view. The error was caused by incorrect named route helpers being used for API search endpoints (e.g., `api_customers_path` instead of `api_customers_search_path`).

This fix updates the `data-searchable-select-url-value` attributes in the view to use the correct `_search_path` suffixes, aligning them with the actual API routes defined in `config/routes.rb`.

## 🔧 **Changes Made**

### Files Modified
- `app/views/delivery_assignments/new.html.erb`
  - Corrected the `data-searchable-select-url-value` for customer, delivery person, and product search dropdowns.

## 🎯 **Business Benefits**
- ✅ Enables the "New Assignment" page to load without errors.
- ✅ Ensures the searchable dropdowns for customers, delivery people, and products function correctly by calling the appropriate API search endpoints.

## 🧪 **Testing**
- [x] The "New Assignment" page loads without `NameError`.
- [ ] Verify searchable dropdowns for customers, delivery people, and products function as expected.

## 🚀 **Deployment Notes**
- These are front-end view changes only.
- No database changes or backend logic modifications.
- Low risk.

## 🔍 **Review Checklist**
- [ ] Corrected path names align with `config/routes.rb`.
- [ ] No unintended side effects introduced.

## 📊 **Impact Assessment**
- **Risk Level**: Low (view fix only)
- **Backward Compatibility**: ✅ Full backward compatibility maintained
- **Performance Impact**: None
- **Database Size**: No change

## 🎉 **Post-Merge Tasks**
1. Verify the "New Assignment" page loads and searchable dropdowns work in development/staging environments.

---

**Branch**: `test1` → `main`  
**Commits**: 1 commit  
**Type**: Bug Fix  
**Priority**: High

---
<a href="https://cursor.com/background-agent?bcId=bc-eb98ed05-5d31-4113-910d-5357791300a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb98ed05-5d31-4113-910d-5357791300a0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>