### PR TITLE
Fix customer delivery person filter on change

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -46,10 +46,11 @@ class Customer < ApplicationRecord
   scope :with_coordinates, -> { where.not(latitude: nil, longitude: nil) }
   scope :without_coordinates, -> { where(latitude: nil, longitude: nil) }
   scope :search, ->(term) {
-    where(
-      "name ILIKE :q OR address ILIKE :q OR phone_number ILIKE :q OR alt_phone_number ILIKE :q OR email ILIKE :q OR member_id ILIKE :q",
-      q: "%#{term}%"
-    )
+    left_joins(:delivery_person)
+      .where(
+        "customers.name ILIKE :q OR customers.address ILIKE :q OR customers.phone_number ILIKE :q OR customers.alt_phone_number ILIKE :q OR customers.email ILIKE :q OR customers.member_id ILIKE :q OR delivery_people.name ILIKE :q",
+        q: "%#{term}%"
+      )
   }
   scope :by_user, ->(user) { where(user: user) }
   scope :by_delivery_person, ->(dp) { where(delivery_person: dp) }

--- a/app/views/customers/index.html.erb
+++ b/app/views/customers/index.html.erb
@@ -95,13 +95,21 @@
           function initCustomerLiveSearch() {
             const input = document.getElementById('customer-live-search');
             const submit = document.getElementById('customer-search-submit');
-            if (!input || !submit) return;
+            if (!input) return;
 
             let debounceTimer = null;
             input.addEventListener('input', function() {
               if (debounceTimer) clearTimeout(debounceTimer);
               debounceTimer = setTimeout(function() {
-                submit.click();
+                if (input.form) {
+                  if (typeof input.form.requestSubmit === 'function') {
+                    input.form.requestSubmit();
+                  } else {
+                    input.form.submit();
+                  }
+                } else {
+                  submit.click();
+                }
               }, 400);
             });
 
@@ -117,7 +125,15 @@
             const submit = document.getElementById('customer-search-submit');
             if (!select || !submit) return;
             select.addEventListener('change', function() {
-              submit.click();
+              if (select.form) {
+                if (typeof select.form.requestSubmit === 'function') {
+                  select.form.requestSubmit();
+                } else {
+                  select.form.submit();
+                }
+              } else {
+                submit.click();
+              }
             });
           }
 


### PR DESCRIPTION
# Pull Request: Fix Customer Delivery Person Filter and Enhance Search

## 📋 **Description**
This PR resolves two issues related to customer filtering and search functionality:
1.  The "Delivery Person" dropdown filter on the customer index page was not correctly applying filters upon selection change.
2.  The general customer search functionality did not include the assigned delivery person's name in its search criteria.

## 🔧 **Changes Made**

### Frontend Enhancements (`app/views/customers/index.html.erb`)
-   **Reliable Form Submission**: Updated JavaScript for both the live search input and the delivery person dropdown. Instead of simulating a click on a hidden submit button, the code now directly calls `form.requestSubmit()` or `form.submit()`. This ensures the form is reliably submitted and filters are applied immediately upon user interaction.

### Backend Enhancements (`app/models/customer.rb`)
-   **Extended Search Scope**: Modified the `Customer.search` scope to include a `left_joins` on the `delivery_person` association. The search criteria now also include `delivery_people.name ILIKE :q`, allowing users to search for customers by their assigned delivery person's name.

## 🎯 **Business Benefits**

### Improved Filtering Usability
-   ✅ The "Delivery Person" dropdown now functions as expected, providing immediate filtering of customer lists, which streamlines operations for users managing customer assignments.

### Enhanced Search Capability
-   ✅ Users can now efficiently find customers by typing the name of their assigned delivery person into the general search box, significantly improving data retrieval and management.

## 🧪 **Testing**
-   [ ] Verify that selecting a delivery person from the dropdown on the customer index page immediately filters the customer list.
-   [ ] Verify that typing a delivery person's name (e.g., "ravi") into the general search box on the customer index page correctly filters customers assigned to that delivery person.
-   [ ] Ensure existing customer search criteria (name, address, phone number, etc.) still function correctly without regressions.

## 🚀 **Deployment Notes**
-   These changes are additive and primarily bug fixes/enhancements.
-   No existing functionality has been removed or altered in a breaking way.
-   The changes are fully backward compatible.

## 🔍 **Review Checklist**
-   [ ] JavaScript form submission logic is robust and correctly uses `requestSubmit()`/`submit()`.
-   [ ] `Customer.search` scope correctly joins `delivery_person` and includes `delivery_people.name` in the search criteria.
-   [ ] No regressions have been introduced to other customer filtering or search functionalities.

## 📊 **Impact Assessment**
-   **Risk Level**: Low (bug fix and minor feature enhancement).
-   **Backward Compatibility**: ✅ Full backward compatibility maintained.
-   **Performance Impact**: Minimal (added a `LEFT JOIN` and an additional `ILIKE` condition to the search scope, which should have negligible impact on typical database sizes).

## 🎉 **Post-Merge Tasks**
-   None specific. The changes are self-contained and immediately effective upon deployment.

---

**Branch**: `test1` → `main`
**Commits**: 2 commits
**Type**: Bug Fix / Enhancement
**Priority**: Medium

---
<a href="https://cursor.com/background-agent?bcId=bc-ff689875-8a19-4334-9f33-473cd5cd5644">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ff689875-8a19-4334-9f33-473cd5cd5644">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

